### PR TITLE
Instantiate KMService objects from mission packs when loaded

### DIFF
--- a/DeMiLAssembly/MissionLoader.cs
+++ b/DeMiLAssembly/MissionLoader.cs
@@ -190,6 +190,12 @@ namespace DeMiLService
 				FactoryMission.UpdateCompatibleMissions();
 			}
 
+			foreach (KMService service in mod.GetModObjects<KMService>())
+			{
+				GameObject obj = UnityEngine.Object.Instantiate(service.gameObject);
+				obj.transform.parent = ModManager.Instance.transform;
+			}
+
 			mod.RemoveServiceObjects();
 			mod.CallMethod("RemoveSoundGroups");
 			mod.CallMethod("RemoveSoundOverrides");

--- a/DeMiLAssembly/MissionLoader.cs
+++ b/DeMiLAssembly/MissionLoader.cs
@@ -160,6 +160,11 @@ namespace DeMiLService
 
 			foreach (string fileName in mod.GetAssetBundlePaths())
 			{
+				if (Path.GetFileName(fileName) != "mod.bundle")
+				{
+					continue;
+				}
+
 				var bundleRequest = AssetBundle.LoadFromFileAsync(fileName);
 				yield return bundleRequest;
 
@@ -193,10 +198,10 @@ namespace DeMiLService
 			foreach (KMService service in mod.GetModObjects<KMService>())
 			{
 				GameObject obj = UnityEngine.Object.Instantiate(service.gameObject);
+				mod.AddServiceObject(obj);
 				obj.transform.parent = ModManager.Instance.transform;
 			}
 
-			mod.RemoveServiceObjects();
 			mod.CallMethod("RemoveSoundGroups");
 			mod.CallMethod("RemoveSoundOverrides");
 

--- a/DeMiLAssembly/Server.cs
+++ b/DeMiLAssembly/Server.cs
@@ -77,7 +77,7 @@ namespace DeMiLService
                 return;
             }
 
-            Logger.Log($"Recieved request {context.Request.Url.OriginalString}");
+            Logger.Log($"Received request {context.Request.Url.OriginalString}");
             coroutineQueue.Enqueue(Send(SwitchURL(context), context));
         }
 


### PR DESCRIPTION
Full change notes:
- KMService objects in mission mods will now be instantiated when loaded and destroyed when unloaded
- DeMiL will now only try to load the main mod.bundle file, and ignore any other bundle files
- Fixed a typo with the request received log message